### PR TITLE
pip 8 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-txStatsD==1.0.0dev20120728
+txStatsD==1.0.0+yola1
 # txStatsD dependencies:
 Twisted==12.2.0
 whisper==0.9.10


### PR DESCRIPTION
1.0.0 came out pretty soon after that snapshot. Even it wasn't pip installable, but sidnei/txstatsd#2 fixed that (mostly). So I uploaded it as a snapshot to YolaPI.